### PR TITLE
update tensorboards controller to set ISTIO_HOSTS

### DIFF
--- a/components/tensorboard-controller/config/base/kustomization.yaml
+++ b/components/tensorboard-controller/config/base/kustomization.yaml
@@ -8,6 +8,7 @@ configMapGenerator:
   - RWO_PVC_SCHEDULING="True"
   - TENSORBOARD_IMAGE=tensorflow/tensorflow:2.1.0
   - ISTIO_GATEWAY=kubeflow/kubeflow-gateway
+  - ISTIO_HOSTS='*'
 patchesStrategicMerge:
 - patches/add_controller_config.yaml
 images:

--- a/components/tensorboard-controller/controllers/tensorboard_controller.go
+++ b/components/tensorboard-controller/controllers/tensorboard_controller.go
@@ -311,13 +311,18 @@ func generateVirtualService(tb *tensorboardv1alpha1.Tensorboard) (*unstructured.
 	if err != nil {
 		return nil, err
 	}
+	istioHost, errH := getEnvVariable("ISTIO_HOSTS")
+	if errH != nil {
+		return nil, errH
+	}
 
 	vsvc := &unstructured.Unstructured{}
 	vsvc.SetAPIVersion("networking.istio.io/v1alpha3")
 	vsvc.SetKind("VirtualService")
 	vsvc.SetName(tb.Name)
 	vsvc.SetNamespace(tb.Namespace)
-	if err := unstructured.SetNestedStringSlice(vsvc.Object, []string{"*"}, "spec", "hosts"); err != nil {
+
+	if err := unstructured.SetNestedStringSlice(vsvc.Object, []string{istioHost}, "spec", "hosts"); err != nil {
 		return nil, fmt.Errorf("Set .spec.hosts error: %v", err)
 	}
 	if err := unstructured.SetNestedStringSlice(vsvc.Object, []string{istioGateway},


### PR DESCRIPTION
Update ISTIO_HOSTS so that virtual services created by the tensorboard controller can have proper specs

image uploaded here: https://console.cloud.google.com/gcr/images/unity-ai-data-mlp-prd/global/kubeflow/tensorboard-controller?project=unity-ai-data-mlp-prd